### PR TITLE
Fix input text fields after 03.2022

### DIFF
--- a/themes/yourname.yaml
+++ b/themes/yourname.yaml
@@ -56,3 +56,9 @@ yourname:
   ### Switches ###
   switch-unchecked-button-color: var(--divider-color)
   switch-unchecked-track-color: var(--divider-color)
+  ### Inputs ###
+  input-fill-color: "rgba(0, 0, 0, 0.5)"
+  input-label-ink-color: var(--primary-color)
+  input-ink-color: var(--primary-color)
+  input-disabled-fill-color: "rgba(0, 0, 0, 0.33)"
+  input-disabled-ink-color: var(--disabled-primary-color)


### PR DESCRIPTION
New values were added and the default is a lil bit too white for this theme.

P.S. I am tinkering with your theme as base quite much. It's by far the best one I could find. Maybe you are interested in my master branch, too.... when it's done. One thing is still missing, making the sidebar transparent completely. Likely my changes will need a custom stylesheet applied, card-mod addin and Lovelace Animated Background addin.